### PR TITLE
Move statement processing out of `main.swift`

### DIFF
--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -59,7 +59,7 @@ enum StatementExecutionResult: Equatable {
     case successfulCreateTable
     case successfulInsert(Int)
     case successfulSelect(ResultSet)
-    case failure(String)
+    case failure(StatementError)
 }
 
 class MemoryBackend {
@@ -75,11 +75,11 @@ class MemoryBackend {
             for statement in statements {
                 switch statement {
                 case .create(let createStatement):
-                    results.append(handleCreateTable(createStatement))
+                    results.append(createTable(createStatement))
                 case .insert(let insertStatement):
-                    results.append(handleInsertTable(insertStatement))
+                    results.append(insertTable(insertStatement))
                 case .select(let selectStatement):
-                    results.append(handleSelectTable(selectStatement))
+                    results.append(selectTable(selectStatement))
                 }
             }
         }
@@ -87,39 +87,12 @@ class MemoryBackend {
         return results
     }
 
-    func handleCreateTable(_ statement: CreateStatement) -> StatementExecutionResult {
-        do {
-            try self.createTable(statement)
-            return .successfulCreateTable
-        } catch {
-            return .failure(error.localizedDescription)
-        }
-    }
-
-    func handleInsertTable(_ statement: InsertStatement) -> StatementExecutionResult {
-        do {
-            try self.insertTable(statement)
-            return .successfulInsert(1)
-        } catch {
-            return .failure(error.localizedDescription)
-        }
-    }
-
-    func handleSelectTable(_ statement: SelectStatement) -> StatementExecutionResult {
-        do {
-            let results = try self.selectTable(statement)
-            return .successfulSelect(results)
-        } catch {
-            return .failure(error.localizedDescription)
-        }
-    }
-
-    func createTable(_ create: CreateStatement) throws {
+    func createTable(_ create: CreateStatement) -> StatementExecutionResult {
         guard case .identifier(let tableName) = create.table.kind else {
-            throw StatementError.misc("Invalid token for table name")
+            return .failure(.misc("Invalid token for table name"))
         }
         if self.tables[tableName] != nil {
-            throw StatementError.tableAlreadyExists(tableName)
+            return .failure(.tableAlreadyExists(tableName))
         }
 
         var columnNames: [String] = []
@@ -129,7 +102,7 @@ class MemoryBackend {
             case .identifier(let name):
                 columnNames.append(name)
             default:
-                throw StatementError.misc("Invalid token for column name")
+                return .failure(.misc("Invalid token for column name"))
             }
 
             switch typeToken.kind {
@@ -142,25 +115,26 @@ class MemoryBackend {
                 case .boolean:
                     columnTypes.append(.boolean)
                 default:
-                    throw StatementError.misc("Invalid column type")
+                    return .failure(.misc("Unsupported column type"))
                 }
             default:
-                throw StatementError.misc("Invalid token for column type")
+                return .failure(.misc("Invalid token for column type"))
             }
         }
 
         let newTable = Table(columnNames, columnTypes)
         self.tables[tableName] = newTable
+        return .successfulCreateTable
     }
 
-    func insertTable(_ insert: InsertStatement) throws {
+    func insertTable(_ insert: InsertStatement) -> StatementExecutionResult {
         switch insert.table.kind {
         case .identifier(let tableName):
             if let table = self.tables[tableName] {
                 if insert.items.count < table.columnNames.count {
-                    throw StatementError.notEnoughValues
+                    return .failure(.notEnoughValues)
                 } else if insert.items.count > table.columnNames.count {
-                    throw StatementError.tooManyValues
+                    return .failure(.tooManyValues)
                 }
 
                 var newRow: [MemoryCell] = []
@@ -170,43 +144,43 @@ class MemoryBackend {
                         if let newCell = makeMemoryCell(token) {
                             newRow.append(newCell)
                         } else {
-                            throw StatementError.misc("Unable to create cell value from token")
+                            return .failure(.misc("Unable to create cell value from token"))
                         }
                     default:
-                        throw StatementError.misc("Unable able to handle this kind of expression")
+                        return .failure(.misc("Unable able to handle this kind of expression"))
                     }
                 }
 
                 table.data.append(newRow)
-                return
+                return .successfulInsert(1)
             } else {
-                throw StatementError.tableDoesNotExist(tableName)
+                return .failure(.tableDoesNotExist(tableName))
             }
         default:
-            throw StatementError.misc("Invalid token for table name")
+            return .failure(.misc("Invalid token for table name"))
         }
     }
 
-    func selectTable(_ select: SelectStatement) throws -> ResultSet {
+    func selectTable(_ select: SelectStatement) -> StatementExecutionResult {
         var columns: [Column] = []
         var resultRows: [[MemoryCell]] = []
 
         guard case .identifier(let tableName) = select.table.kind else {
-            throw StatementError.misc("Invalid token for table name")
+            return .failure(.misc("Invalid token for table name"))
         }
         guard let table = self.tables[tableName] else {
-            throw StatementError.tableDoesNotExist(tableName)
+            return .failure(.tableDoesNotExist(tableName))
         }
 
         for item in select.items {
             switch item {
             case .expression(let expression):
                 if case .failure(let error) = typeCheck(expression, table) {
-                    throw error
+                    return .failure(error)
                 }
             case .expressionWithAlias(let expression, _):
                 if case .failure(let error) = typeCheck(expression, table) {
-                    throw error
+                    return .failure(error)
                 }
             case .star:
                 continue
@@ -216,10 +190,10 @@ class MemoryBackend {
         if let whereClause = select.whereClause {
             switch typeCheck(whereClause, table) {
             case .failure(let error):
-                throw error
+                return .failure(error)
             case .success(let type):
                 if type != .boolean {
-                    throw StatementError.whereClauseNotBooleanExpression
+                    return .failure(.whereClauseNotBooleanExpression)
                 }
             }
         }
@@ -238,7 +212,7 @@ class MemoryBackend {
                 switch item {
                 case .expression(let expression):
                     guard let value = evaluateExpression(expression, table, tableRow) else {
-                        throw StatementError.misc("Unable to evaluate expression in SELECT")
+                        return .failure(.misc("Unable to evaluate expression in SELECT"))
                     }
 
                     if isFirstRow {
@@ -264,12 +238,12 @@ class MemoryBackend {
                     resultRow.append(value)
                 case .expressionWithAlias(let expression, let aliasToken):
                     guard let value = evaluateExpression(expression, table, tableRow) else {
-                        throw StatementError.misc("Unable to evaulate expression")
+                        return .failure(.misc("Unable to evaulate expression"))
                     }
 
                     if isFirstRow {
                         guard case .identifier(let alias) = aliasToken.kind else {
-                            throw StatementError.misc("Bad alias token encountered")
+                            return .failure(.misc("Bad alias token encountered"))
                         }
 
                         switch value {
@@ -297,7 +271,7 @@ class MemoryBackend {
             isFirstRow = false
             resultRows.append(resultRow)
         }
-        return ResultSet(columns, resultRows)
+        return .successfulSelect(ResultSet(columns, resultRows))
     }
 
     func typeCheck(_ expression: Expression, _ table: Table) -> TypeCheckResult {

--- a/MyOwnSQL/StatementError.swift
+++ b/MyOwnSQL/StatementError.swift
@@ -18,7 +18,7 @@ enum StatementError: Error, Equatable, LocalizedError {
     case invalidExpression
     case misc(String)
 
-    var errorDescription: String? {
+    var errorDescription: String {
         switch self {
         case .unsupportedColumnType:
             return "Unsupported column type"

--- a/MyOwnSQL/main.swift
+++ b/MyOwnSQL/main.swift
@@ -12,115 +12,91 @@ print("Welcome to MyOwnSQL!\n")
 
 while true {
     print("SQL> ", terminator: "")
-    let input = readLine()
 
-    if input!.isEmpty {
+    guard let input = readLine() else {
         print("Please enter a statement")
         continue
     }
 
-    switch parse(input!) {
-    case .failure(let errorMessage):
-        print(errorMessage)
-    case .success(let statements):
-        for statement in statements {
-            switch statement {
-            case .create(let createStatement):
-                handleCreateTable(createStatement)
-            case .insert(let insertStatement):
-                handleInsertTable(insertStatement)
-            case .select(let selectStatement):
-                handleSelectTable(selectStatement)
-            }
+    let results = database.executeStatements(input)
+    for result in results {
+        switch result {
+        case .failure(let error):
+            print(error.errorDescription)
+        case .successfulCreateTable:
+            print("Table created")
+        case .successfulInsert(let rows):
+            // TODO: One of these days, I need to be able to support
+            //       inserting more than one row at a time
+            print("\(rows) row(s) inserted")
+        case .successfulSelect(let resultSet):
+            printResultSet(resultSet)
         }
     }
 }
 
-func handleCreateTable(_ statement: CreateStatement) {
-    do {
-        try database.createTable(statement)
-        print("Table created!")
-    } catch {
-        print(error.localizedDescription)
+func printResultSet(_ resultSet: ResultSet) {
+    if resultSet.rows.isEmpty {
+        print("No rows selected")
+        return
     }
-}
 
-func handleInsertTable(_ statement: InsertStatement) {
-    do {
-        try database.insertTable(statement)
-        print("One row inserted!")
-    } catch {
-        print(error.localizedDescription)
+    // First we need to compute the column widths, starting with the
+    // lengths of the column names themselves...
+    var columnWidths: [Int] = []
+    for column in resultSet.columns {
+        columnWidths.append(column.name.count)
     }
-}
-
-func handleSelectTable(_ statement: SelectStatement) {
-    do {
-        let results = try database.selectTable(statement)
-        if results.rows.isEmpty {
-            print("No rows selected")
-            return
-        }
-
-        // First we need to compute the column widths, starting with the
-        // lengths of the column names themselves...
-        var columnWidths: [Int] = []
-        for column in results.columns {
-            columnWidths.append(column.name.count)
-        }
-        // Next we need to see if any of the column values themselves
-        // are wider than their respective column names...
-        for row in results.rows {
-            for (i, column) in row.enumerated() {
-                var printedValue: String
-                switch column {
-                case .intValue(let integer):
-                    printedValue = String(integer)
-                case .textValue(let string):
-                    printedValue = string
-                case .booleanValue(let boolean):
-                    printedValue = String(boolean)
-                }
-                if printedValue.count > columnWidths[i] {
-                    columnWidths[i] = printedValue.count
-                }
+    // Next we need to see if any of the column values themselves
+    // are wider than their respective column names...
+    for row in resultSet.rows {
+        for (i, column) in row.enumerated() {
+            var printedValue: String
+            switch column {
+            case .intValue(let integer):
+                printedValue = String(integer)
+            case .textValue(let string):
+                printedValue = string
+            case .booleanValue(let boolean):
+                printedValue = String(boolean)
+            }
+            if printedValue.count > columnWidths[i] {
+                columnWidths[i] = printedValue.count
             }
         }
+    }
 
-        // Now we can finally print the column header
-        var columnHeader = ""
-        for (i, column) in results.columns.enumerated() {
-            columnHeader.append("| ")
-            columnHeader.append(column.name.padding(toLength: columnWidths[i], withPad: " ", startingAt: 0))
-            columnHeader.append(" ")
-        }
-        columnHeader.append("|")
-        print(columnHeader)
-        let separator = String(repeating: "=", count: columnHeader.count)
-        print(separator)
+    // Now we can finally print the column header
+    var columnHeader = ""
+    for (i, column) in resultSet.columns.enumerated() {
+        columnHeader.append("| ")
+        columnHeader.append(column.name.padding(toLength: columnWidths[i], withPad: " ", startingAt: 0))
+        columnHeader.append(" ")
+    }
+    columnHeader.append("|")
+    print(columnHeader)
+    let separator = String(repeating: "=", count: columnHeader.count)
+    print(separator)
 
-        // ... and then we can print the result set, with padding
-        // to insure that all columns are aligned.
-        for row in results.rows {
-            var rowLine = ""
-            for (i, columnValue) in row.enumerated() {
-                var printedValue: String
-                switch columnValue {
-                case .intValue(let integer):
-                    printedValue = String(integer)
-                case .textValue(let string):
-                    printedValue = string
-                case .booleanValue(let boolean):
-                    printedValue = String(boolean)
-                }
-                rowLine.append("| ")
-                rowLine.append(printedValue.padding(toLength: columnWidths[i], withPad: " ", startingAt: 0))
-                rowLine.append(" ")
+    // ... and then we can print the result set, with padding
+    // to insure that all columns are aligned.
+    for row in resultSet.rows {
+        var rowLine = ""
+        for (i, columnValue) in row.enumerated() {
+            var printedValue: String
+            switch columnValue {
+            case .intValue(let integer):
+                printedValue = String(integer)
+            case .textValue(let string):
+                printedValue = string
+            case .booleanValue(let boolean):
+                printedValue = String(boolean)
             }
-            rowLine.append("|")
-            print(rowLine)
+            rowLine.append("| ")
+            rowLine.append(printedValue.padding(toLength: columnWidths[i], withPad: " ", startingAt: 0))
+            rowLine.append(" ")
         }
-    } catch {
-        print(error.localizedDescription)
+        rowLine.append("|")
+        print(rowLine)
     }
 }

--- a/MyOwnSQLTests/MemoryTests.swift
+++ b/MyOwnSQLTests/MemoryTests.swift
@@ -39,7 +39,7 @@ class MemoryTests: XCTestCase {
             XCTFail("Something unexpected happened")
             return
         }
-        XCTAssertEqual(result, .failure("Table dresses already exists"))
+        XCTAssertEqual(result, .failure(.tableAlreadyExists("dresses")))
     }
 
     func testSuccessfulExecutionOfInsertStatement() throws {
@@ -85,7 +85,7 @@ class MemoryTests: XCTestCase {
             XCTFail("Something unexpected happened")
             return
         }
-        XCTAssertEqual(result, .failure("Table does_not_exist does not exist"))
+        XCTAssertEqual(result, .failure(.tableDoesNotExist("does_not_exist")))
     }
 
     func testInsertFailsForNotEnoughValues() throws {
@@ -102,7 +102,7 @@ class MemoryTests: XCTestCase {
             XCTFail("Something unexpected happened")
             return
         }
-        XCTAssertEqual(result, .failure("Not enough values"))
+        XCTAssertEqual(result, .failure(.notEnoughValues))
     }
 
     func testInsertFailsForTooManyValues() throws {
@@ -119,7 +119,7 @@ class MemoryTests: XCTestCase {
             XCTFail("Something unexpected happened")
             return
         }
-        XCTAssertEqual(result, .failure("Too many values"))
+        XCTAssertEqual(result, .failure(.tooManyValues))
     }
 
     func testSelectLiteralsStatement() throws {
@@ -241,7 +241,7 @@ class MemoryTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(result, .failure("Invalid expression"))
+        XCTAssertEqual(result, .failure(.invalidExpression))
     }
 
     func testSelectFailsForNonexistentTable() throws {
@@ -256,7 +256,7 @@ class MemoryTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(result, .failure("Table does_not_exist does not exist"))
+        XCTAssertEqual(result, .failure(.tableDoesNotExist("does_not_exist")))
     }
 
     func testSelectFailsForNonexistentColumn() throws {
@@ -271,7 +271,7 @@ class MemoryTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(result, .failure("Column does_not_exist does not exist"))
+        XCTAssertEqual(result, .failure(.columnDoesNotExist("does_not_exist")))
     }
 
     func testSelectFailsForWhereClauseReferencingNonexistentColumn() throws {
@@ -286,7 +286,7 @@ class MemoryTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(result, .failure("Column label does not exist"))
+        XCTAssertEqual(result, .failure(.columnDoesNotExist("label")))
     }
 
     func testSelectFailsForWhereClauseThatIsNotBooleanExpression() throws {
@@ -301,7 +301,7 @@ class MemoryTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(result, .failure("WHERE clause must be boolean expression"))
+        XCTAssertEqual(result, .failure(.whereClauseNotBooleanExpression))
     }
 
     func testSelectFailsForWhereClauseThatIsNotValidExpression() throws {
@@ -317,6 +317,6 @@ class MemoryTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(result, .failure("Invalid expression"))
+        XCTAssertEqual(result, .failure(.invalidExpression))
     }
 }

--- a/MyOwnSQLTests/MemoryTests.swift
+++ b/MyOwnSQLTests/MemoryTests.swift
@@ -9,18 +9,9 @@ import XCTest
 
 class MemoryTests: XCTestCase {
     func testSuccessfulExecutionOfCreateStatement() throws {
-        let source = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .create(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
-            return
-        }
-
         let database = MemoryBackend()
-        XCTAssertNoThrow(try database.createTable(statement))
+        let source = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(source)
 
         XCTAssertEqual(database.tables.count, 1)
 
@@ -35,49 +26,37 @@ class MemoryTests: XCTestCase {
     }
 
     func testCreateFailsForExistentTable() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
+        // Create a table first...
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let firstInput = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(firstInput)
 
-        // ... and now try to create a table with the same name from an actual statement...
-        let source = "CREATE TABLE dresses (id INT);"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
+        // ... and now try to create another table with the same name...
+        let secondInput = "CREATE TABLE dresses (id INT);"
+        let results = database.executeStatements(secondInput)
+
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
             return
         }
-        guard case .create(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
-            return
-        }
-
-        XCTAssertThrowsError(try database.createTable(statement)) { error in
-            XCTAssertEqual(error as! StatementError, .tableAlreadyExists("dresses"))
-        }
+        XCTAssertEqual(result, .failure("Table dresses already exists"))
     }
 
     func testSuccessfulExecutionOfInsertStatement() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
+        // Create the table first...
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
 
         // ... and _now_ insert the row from an actual statement...
-        let source = "INSERT INTO dresses VALUES (1, 'Long black velvet gown from Lauren', true);"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .insert(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
-            return
-        }
+        let insert = "INSERT INTO dresses VALUES (1, 'Long black velvet gown from Lauren', true);"
+        let results = database.executeStatements(insert)
 
-        XCTAssertNoThrow(try database.insertTable(statement))
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+        XCTAssertEqual(result, .successfulInsert(1))
 
         let dressesTable = database.tables["dresses"]!
         let dresses = dressesTable.data
@@ -93,105 +72,74 @@ class MemoryTests: XCTestCase {
     }
 
     func testInsertFailsForNonexistentTable() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
+        // Create the table first...
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
 
         // ... and _now_ insert the row from an actual statement...
-        let source = "INSERT INTO does_not_exist VALUES (42);"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .insert(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
-            return
-        }
+        let badInsert = "INSERT INTO does_not_exist VALUES (42);"
+        let results = database.executeStatements(badInsert)
 
-        XCTAssertThrowsError(try database.insertTable(statement)) { error in
-            XCTAssertEqual(error as! StatementError, .tableDoesNotExist("does_not_exist"))
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
         }
+        XCTAssertEqual(result, .failure("Table does_not_exist does not exist"))
     }
 
     func testInsertFailsForNotEnoughValues() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
+        // Create the table first...
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
 
         // ... and _now_ insert the row from an actual statement...
-        let source = "INSERT INTO dresses VALUES (42);"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .insert(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
-            return
-        }
+        let badInsert = "INSERT INTO dresses VALUES (42);"
+        let results = database.executeStatements(badInsert)
 
-        XCTAssertThrowsError(try database.insertTable(statement)) { error in
-            XCTAssertEqual(error as! StatementError, .notEnoughValues)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
         }
+        XCTAssertEqual(result, .failure("Not enough values"))
     }
 
     func testInsertFailsForTooManyValues() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
+        // Create the table first...
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
 
         // ... and _now_ insert the row from an actual statement...
-        let source = "INSERT INTO dresses VALUES (1, 'Velvet dress', true, 'Bought at Goodwill');"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .insert(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
-            return
-        }
+        let badInsert = "INSERT INTO dresses VALUES (1, 'Velvet dress', true, 'Bought at Goodwill');"
+        let results = database.executeStatements(badInsert)
 
-        XCTAssertThrowsError(try database.insertTable(statement)) { error in
-            XCTAssertEqual(error as! StatementError, .tooManyValues)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
         }
+        XCTAssertEqual(result, .failure("Too many values"))
     }
 
     func testSelectLiteralsStatement() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
-
-        // Now create some data manually...
-        let row: [MemoryCell] = [
-            .intValue(1),
-            .textValue("Long black velvet gown from Lauren"),
-            .booleanValue(true)
-        ]
-        table.data.append(row)
-
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
+        let insert = "INSERT INTO dresses VALUES (1, 'Velvet dress', true);"
+        let _ = database.executeStatements(insert)
 
-        // ... and _now_ SELECT a set of expressions from the table...
-        let source = "SELECT 42, 'something', false FROM dresses;"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
+        let select = "SELECT 42, 'something', false FROM dresses;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
             return
         }
-        guard case .select(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
+
+        guard case .successfulSelect(let resultSet) = result else {
+            XCTFail("Something unexpected happened")
             return
         }
-        let resultSet = try database.selectTable(statement)
 
         let expectedColumnNames = ["col_0", "col_1", "col_2"]
         let actualColumnNames = resultSet.columns.map { column in
@@ -210,33 +158,23 @@ class MemoryTests: XCTestCase {
     }
 
     func testSelectActualColumnsStatement() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
-
-        // Now create some data manually...
-        let row: [MemoryCell] = [
-            .intValue(1),
-            .textValue("Long black velvet gown from Lauren"),
-            .booleanValue(true)
-        ]
-        table.data.append(row)
-
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
+        let insert = "INSERT INTO dresses VALUES (1, 'Velvet dress', true);"
+        let _ = database.executeStatements(insert)
 
-        // ... and _now_ SELECT a set of expressions from the table...
-        let source = "SELECT id, description, is_in_season FROM dresses;"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
+        let select = "SELECT id, description, is_in_season FROM dresses;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
             return
         }
-        guard case .select(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
+
+        guard case .successfulSelect(let resultSet) = result else {
+            XCTFail("Something unexpected happened")
             return
         }
-        let resultSet = try database.selectTable(statement)
 
         let expectedColumnNames = ["id", "description", "is_in_season"]
         let actualColumnNames = resultSet.columns.map { column in
@@ -247,7 +185,7 @@ class MemoryTests: XCTestCase {
         XCTAssertEqual(resultSet.rows.count, 1)
         let expectedRow: [MemoryCell] = [
             .intValue(1),
-            .textValue("Long black velvet gown from Lauren"),
+            .textValue("Velvet dress"),
             .booleanValue(true)
         ]
         let actualRow = resultSet.rows[0]
@@ -255,42 +193,25 @@ class MemoryTests: XCTestCase {
     }
 
     func testSelectWithWhereClause() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_fabulous"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
-
-        // Now create some data manually...
-        let rows: [[MemoryCell]] = [
-            [
-                .intValue(1),
-                .textValue("Long black velvet gown from Lauren"),
-                .booleanValue(true),
-            ],
-            [
-                .intValue(2),
-                .textValue("Linen shirt"),
-                .booleanValue(false),
-            ],
-        ]
-        for row in rows {
-            table.data.append(row)
-        }
-
         let database = MemoryBackend()
-        database.tables = ["clothes": table]
+        let create = "CREATE TABLE clothes (id int, description text, is_fabulous boolean);"
+        let _ = database.executeStatements(create)
+        let insert1 = "INSERT INTO clothes VALUES (1, 'Long black velvet gown from Lauren', true);"
+        let _ = database.executeStatements(insert1)
+        let insert2 = "INSERT INTO clothes VALUES (2, 'Linen shirt', false);"
+        let _ = database.executeStatements(insert2)
 
-        // ... and _now_ SELECT a set of expressions from the table...
-        let source = "SELECT id, description FROM clothes WHERE is_fabulous = true;"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
+        let select = "SELECT id, description FROM clothes WHERE is_fabulous = true;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
             return
         }
-        guard case .select(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
+
+        guard case .successfulSelect(let resultSet) = result else {
+            XCTFail("Something unexpected happened")
             return
         }
-        let resultSet = try database.selectTable(statement)
 
         let expectedColumnNames = ["id", "description"]
         let actualColumnNames = resultSet.columns.map { column in
@@ -308,142 +229,94 @@ class MemoryTests: XCTestCase {
     }
 
     func testSelectFailsForBadExpressionInSelectClause() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
 
         // Cannot add string to int
-        let source = "SELECT id + description FROM dresses;"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .select(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
+        let select = "SELECT id + description FROM dresses;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
             return
         }
 
-        XCTAssertThrowsError(try database.selectTable(statement)) { error in
-            XCTAssertEqual(error as! StatementError, .invalidExpression)
-        }
+        XCTAssertEqual(result, .failure("Invalid expression"))
     }
 
     func testSelectFailsForNonexistentTable() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
 
-        let source = "SELECT 42 FROM does_not_exist;"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .select(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
+        let select = "SELECT 42 FROM does_not_exist;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
             return
         }
 
-        XCTAssertThrowsError(try database.selectTable(statement)) { error in
-            XCTAssertEqual(error as! StatementError, .tableDoesNotExist("does_not_exist"))
-        }
+        XCTAssertEqual(result, .failure("Table does_not_exist does not exist"))
     }
 
     func testSelectFailsForNonexistentColumn() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
 
-        let source = "SELECT does_not_exist FROM dresses;"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .select(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
+        let select = "SELECT does_not_exist FROM dresses;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
             return
         }
 
-        XCTAssertThrowsError(try database.selectTable(statement)) { error in
-            XCTAssertEqual(error as! StatementError, .columnDoesNotExist("does_not_exist"))
-        }
+        XCTAssertEqual(result, .failure("Column does_not_exist does not exist"))
     }
 
     func testSelectFailsForWhereClauseReferencingNonexistentColumn() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
 
-        let source = "SELECT * FROM dresses WHERE label = 'Lauren';"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .select(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
+        let select = "SELECT * FROM dresses WHERE label = 'Lauren';"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
             return
         }
 
-        XCTAssertThrowsError(try database.selectTable(statement)) { error in
-            XCTAssertEqual(error as! StatementError, .columnDoesNotExist("label"))
-        }
+        XCTAssertEqual(result, .failure("Column label does not exist"))
     }
 
     func testSelectFailsForWhereClauseThatIsNotBooleanExpression() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
 
-        let source = "SELECT * FROM dresses WHERE 42;"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .select(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
+        let select = "SELECT * FROM dresses WHERE 42;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
             return
         }
 
-        XCTAssertThrowsError(try database.selectTable(statement)) { error in
-            XCTAssertEqual(error as! StatementError, .whereClauseNotBooleanExpression)
-        }
+        XCTAssertEqual(result, .failure("WHERE clause must be boolean expression"))
     }
 
     func testSelectFailsForWhereClauseThatIsNotValidExpression() throws {
-        // Create table manually first...
-        let columnNames = ["id", "description", "is_in_season"]
-        let columnTypes: [ColumnType] = [.int, .text, .boolean]
-        let table = Table(columnNames, columnTypes)
         let database = MemoryBackend()
-        database.tables = ["dresses": table]
+        let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
+        let _ = database.executeStatements(create)
 
         // `id` is an int, and so the WHERE clause should be invalid
-        let source = "SELECT * FROM dresses WHERE id = '42';"
-        guard case .success(let statements) = parse(source) else {
-            XCTFail("Parsing failed unexpectedly")
-            return
-        }
-        guard case .select(let statement) = statements[0] else {
-            XCTFail("Unexpected statement type encountered")
+        let select = "SELECT * FROM dresses WHERE id = '42';"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
             return
         }
 
-        XCTAssertThrowsError(try database.selectTable(statement)) { error in
-            XCTAssertEqual(error as! StatementError, .invalidExpression)
-        }
+        XCTAssertEqual(result, .failure("Invalid expression"))
     }
 }


### PR DESCRIPTION
Up until now, some logic for processing SQL statements was mixed in with the formatting of their results in `main.swift`. This was starting to make me queasy and so that's been addressed here. As an added bonus, I was able to simplify a bunch of tests by using the new top-level `executeStatements()` function instead of calling low-level `lex()` and `parse()` functions and having to do a bunch of error handling. Plus, I felt that the tests "knew" too much about implementation details by going behind the APIs to mock up data. And so, I feel like the tests are far easier to understand, and less susceptible to breakage if I happen to switch out, say, how table rows are implemented in the future.