### PR TITLE
Support `NULL` in multiple contexts

### DIFF
--- a/MyOwnSQL/LexerTypes.swift
+++ b/MyOwnSQL/LexerTypes.swift
@@ -30,6 +30,9 @@ enum Keyword: String, CaseIterable {
     case `as` = "as"
     case and = "and"
     case or = "or"
+    case not = "not"
+    case null = "null"
+    case `is` = "is"
 }
 
 enum Symbol: String, CaseIterable {

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -157,7 +157,7 @@ class MemoryBackend {
                     case .term(let token):
                         if let newCell = makeMemoryCell(token) {
                             if case .null = newCell, !table.columnNullalities[i] {
-                                return .failure(.cannotInsertNull(table.columnNames[i]))
+                                return .failure(.columnCannotBeNull(table.columnNames[i]))
                             }
                             newRow.append(newCell)
                         } else {
@@ -365,7 +365,11 @@ class MemoryBackend {
                     return .failure(error)
                 case .success(let expressionType):
                     let columnType = table.columnTypes[columnIndex]
-                    if expressionType != columnType {
+                    if expressionType == .null && !table.columnNullalities[columnIndex] {
+                        return .failure(.columnCannotBeNull(table.columnNames[columnIndex]))
+                    } else if expressionType != .null && expressionType != columnType {
+                        // TODO: This is super hacky and I need to deal with nulls better;
+                        //       I'm conflating types and values here and a couple of other places.
                         return .failure(.typeMismatch)
                     }
                 }

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -104,15 +104,15 @@ class MemoryBackend {
 
         var columnNames: [String] = []
         var columnTypes: [ColumnType] = []
-        for case .column(let nameToken, let typeToken) in create.columns {
-            switch nameToken.kind {
+        for column in create.columns {
+            switch column.nameToken.kind {
             case .identifier(let name):
                 columnNames.append(name)
             default:
                 return .failure(.misc("Invalid token for column name"))
             }
 
-            switch typeToken.kind {
+            switch column.typeToken.kind {
             case .keyword(let keyword):
                 switch keyword {
                 case .text:

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -11,6 +11,7 @@ enum MemoryCell: Equatable {
     case intValue(Int)
     case textValue(String)
     case booleanValue(Bool)
+    case null
 }
 
 enum ColumnType {
@@ -42,11 +43,13 @@ struct ResultSet: Equatable {
 class Table {
     var columnNames: [String]
     var columnTypes: [ColumnType]
+    var columnNullalities: [Bool]
     var data: [String : [MemoryCell]]
 
-    init(_ columnNames: [String], _ columnTypes: [ColumnType]) {
+    init(_ columnNames: [String], _ columnTypes: [ColumnType], _ columnNullalities: [Bool]) {
         self.columnNames = columnNames
         self.columnTypes = columnTypes
+        self.columnNullalities = columnNullalities
         self.data = [:]
     }
 }
@@ -104,6 +107,7 @@ class MemoryBackend {
 
         var columnNames: [String] = []
         var columnTypes: [ColumnType] = []
+        var columnNullalities: [Bool] = []
         for column in create.columns {
             switch column.nameToken.kind {
             case .identifier(let name):
@@ -127,9 +131,11 @@ class MemoryBackend {
             default:
                 return .failure(.misc("Invalid token for column type"))
             }
+
+            columnNullalities.append(column.isNullable)
         }
 
-        let newTable = Table(columnNames, columnTypes)
+        let newTable = Table(columnNames, columnTypes, columnNullalities)
         self.tables[tableName] = newTable
         return .successfulCreateTable
     }
@@ -145,10 +151,13 @@ class MemoryBackend {
                 }
 
                 var newRow: [MemoryCell] = []
-                for item in insert.items {
+                for (i, item) in insert.items.enumerated() {
                     switch item {
                     case .term(let token):
                         if let newCell = makeMemoryCell(token) {
+                            if case .null = newCell, !table.columnNullalities[i] {
+                                return .failure(.cannotInsertNull(table.columnNames[i]))
+                            }
                             newRow.append(newCell)
                         } else {
                             return .failure(.misc("Unable to create cell value from token"))
@@ -239,6 +248,9 @@ class MemoryBackend {
                                 columns.append(Column("col_\(i)", .text))
                             case .booleanValue:
                                 columns.append(Column("col_\(i)", .boolean))
+                            // TODO: Need to think about this more deeply...
+                            case .null:
+                                columns.append(Column("col_\(i)", .text))
                             }
                         }
                     }
@@ -261,6 +273,9 @@ class MemoryBackend {
                             columns.append(Column(alias, .text))
                         case .booleanValue:
                             columns.append(Column(alias, .boolean))
+                        // TODO: Need to think about this more deeply...
+                        case .null:
+                            columns.append(Column(alias, .text))
                         }
                     }
 
@@ -484,6 +499,8 @@ func evaluateExpression(_ expr: Expression, _ table: Table, _ tableRow: [MemoryC
                 }
             }
             return nil
+        case .keyword(.null):
+            return .null
         default:
             return nil
         }
@@ -581,6 +598,8 @@ func makeMemoryCell(_ token: Token) -> MemoryCell? {
         default:
             return .booleanValue(false)
         }
+    case .keyword(.null):
+        return .null
     default:
         return nil
     }

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -448,6 +448,13 @@ class MemoryBackend {
                 default:
                     return .failure(StatementError.invalidExpression)
                 }
+            case .keyword(.is):
+                switch (leftType, rightType) {
+                case (.null, _), (_, .null):
+                    return .success(.boolean)
+                default:
+                    return .failure(.invalidExpression)
+                }
             case .symbol(.equals), .symbol(.notEquals):
                 if leftType == rightType {
                     return .success(.boolean)
@@ -541,6 +548,13 @@ func evaluateExpression(_ expr: Expression, _ table: Table, _ tableRow: [MemoryC
                 return leftValue
             default:
                 return nil
+            }
+        case .keyword(.is):
+            switch (leftValue, rightValue) {
+            case (.null, .null):
+                return .booleanValue(true)
+            default:
+                return .booleanValue(false)
             }
         case .symbol(.plus):
             switch (leftValue, rightValue) {

--- a/MyOwnSQL/ParserTypes.swift
+++ b/MyOwnSQL/ParserTypes.swift
@@ -17,7 +17,44 @@ enum SelectItem: Equatable {
 }
 
 enum Definition: Equatable {
-    case column(Token, Token)
+    case implicitlyNullableColumn(Token, Token)
+    case explicitlyNullableColumn(Token, Token, Token)
+    case notNullableColumn(Token, Token, [Token])
+}
+
+extension Definition {
+    var nameToken: Token {
+        switch self {
+        case .implicitlyNullableColumn(let nameToken, _):
+            return nameToken
+        case .explicitlyNullableColumn(let nameToken, _, _):
+            return nameToken
+        case .notNullableColumn(let nameToken, _, _):
+            return nameToken
+        }
+    }
+
+    var typeToken: Token {
+        switch self {
+        case .implicitlyNullableColumn(_, let typeToken):
+            return typeToken
+        case .explicitlyNullableColumn(_, let typeToken, _):
+            return typeToken
+        case .notNullableColumn(_, let typeToken, _):
+            return typeToken
+        }
+    }
+
+    var isNullable: Bool {
+        switch self {
+        case .implicitlyNullableColumn(_, _):
+            return true
+        case .explicitlyNullableColumn(_, _, _):
+            return true
+        case .notNullableColumn(_, _, _):
+            return false
+        }
+    }
 }
 
 struct CreateStatement: Equatable {

--- a/MyOwnSQL/ParserTypes.swift
+++ b/MyOwnSQL/ParserTypes.swift
@@ -7,6 +7,7 @@
 
 indirect enum Expression: Equatable {
     case term(Token)
+    case unary(Expression, [Token])
     case binary(Expression, Expression, Token)
 }
 

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -101,6 +101,7 @@ outer:
         let binaryOperators: [TokenKind] = [
             .keyword(.and),
             .keyword(.or),
+            .keyword(.is),
             .symbol(.equals),
             .symbol(.notEquals),
             .symbol(.concatenate),

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -78,6 +78,19 @@ func parseExpression(_ tokens: [Token], _ tokenCursor: Int, _ delimeters: [Token
         default:
             return .failure("Could not parse expression")
         }
+
+        if tokenCursorCopy+2 < tokens.count &&
+            .keyword(.is) == tokens[tokenCursorCopy].kind &&
+            .keyword(.not) == tokens[tokenCursorCopy+1].kind &&
+            .keyword(.null) == tokens[tokenCursorCopy+2].kind {
+            expression = .unary(expression, [tokens[tokenCursorCopy], tokens[tokenCursorCopy+1], tokens[tokenCursorCopy+2]])
+            tokenCursorCopy += 3
+        } else if tokenCursorCopy+1 < tokens.count &&
+            .keyword(.is) == tokens[tokenCursorCopy].kind &&
+            .keyword(.null) == tokens[tokenCursorCopy+1].kind {
+            expression = .unary(expression, [tokens[tokenCursorCopy], tokens[tokenCursorCopy+1]])
+            tokenCursorCopy += 2
+        }
     }
 
     // OK... now we've got an expression at this point;
@@ -101,7 +114,6 @@ outer:
         let binaryOperators: [TokenKind] = [
             .keyword(.and),
             .keyword(.or),
-            .keyword(.is),
             .symbol(.equals),
             .symbol(.notEquals),
             .symbol(.concatenate),

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -39,7 +39,7 @@ func parseTermExpression(_ tokens: [Token], _ tokenCursor: Int) -> ParseHelperRe
     // TODO: Consider instead being able to handle tokens
     //       for true and false keywords, and removing the
     //       boolean token type
-    case .identifier, .string, .numeric, .boolean:
+    case .identifier, .string, .numeric, .boolean, .keyword(.null):
         return .success(tokenCursor+1, Expression.term(maybeTermToken))
     default:
         return .failure("Term expression not found")

--- a/MyOwnSQL/StatementError.swift
+++ b/MyOwnSQL/StatementError.swift
@@ -13,6 +13,7 @@ enum StatementError: Error, Equatable, LocalizedError {
     case tableDoesNotExist(String)
     case columnDoesNotExist(String)
     case whereClauseNotBooleanExpression
+    case cannotInsertNull(String)
     case typeMismatch
     case notEnoughValues
     case tooManyValues
@@ -31,6 +32,8 @@ enum StatementError: Error, Equatable, LocalizedError {
             return "Column \(columnName) does not exist"
         case .whereClauseNotBooleanExpression:
             return "WHERE clause must be boolean expression"
+        case .cannotInsertNull(let columnName):
+            return "Cannot insert NULL into column \(columnName)"
         case .typeMismatch:
             return "Type mismatch in SET clause"
         case .notEnoughValues:

--- a/MyOwnSQL/StatementError.swift
+++ b/MyOwnSQL/StatementError.swift
@@ -13,7 +13,7 @@ enum StatementError: Error, Equatable, LocalizedError {
     case tableDoesNotExist(String)
     case columnDoesNotExist(String)
     case whereClauseNotBooleanExpression
-    case cannotInsertNull(String)
+    case columnCannotBeNull(String)
     case typeMismatch
     case notEnoughValues
     case tooManyValues
@@ -32,8 +32,8 @@ enum StatementError: Error, Equatable, LocalizedError {
             return "Column \(columnName) does not exist"
         case .whereClauseNotBooleanExpression:
             return "WHERE clause must be boolean expression"
-        case .cannotInsertNull(let columnName):
-            return "Cannot insert NULL into column \(columnName)"
+        case .columnCannotBeNull(let columnName):
+            return "Column \(columnName) cannot be NULL"
         case .typeMismatch:
             return "Type mismatch in SET clause"
         case .notEnoughValues:

--- a/MyOwnSQL/main.swift
+++ b/MyOwnSQL/main.swift
@@ -61,6 +61,8 @@ func printResultSet(_ resultSet: ResultSet) {
                 printedValue = string
             case .booleanValue(let boolean):
                 printedValue = String(boolean)
+            case .null:
+                printedValue = ""
             }
             if printedValue.count > columnWidths[i] {
                 columnWidths[i] = printedValue.count
@@ -93,6 +95,8 @@ func printResultSet(_ resultSet: ResultSet) {
                 printedValue = string
             case .booleanValue(let boolean):
                 printedValue = String(boolean)
+            case .null:
+                printedValue = ""
             }
             rowLine.append("| ")
             rowLine.append(printedValue.padding(toLength: columnWidths[i], withPad: " ", startingAt: 0))

--- a/MyOwnSQLTests/MemoryTests.swift
+++ b/MyOwnSQLTests/MemoryTests.swift
@@ -304,6 +304,9 @@ class MemoryTests: XCTestCase {
             ("SELECT 1 IS NULL FROM foo;", .booleanValue(false)),
             ("SELECT 'one' IS NULL FROM foo;", .booleanValue(false)),
             ("SELECT TRUE IS NULL FROM foo;", .booleanValue(false)),
+            ("SELECT 1 IS NOT NULL FROM foo;", .booleanValue(true)),
+            ("SELECT 'one' IS NOT NULL FROM foo;", .booleanValue(true)),
+            ("SELECT TRUE IS NOT NULL FROM foo;", .booleanValue(true)),
         ] {
             let results = database.executeStatements(select)
             guard let result = results.first else {

--- a/MyOwnSQLTests/ParserTests.swift
+++ b/MyOwnSQLTests/ParserTests.swift
@@ -238,6 +238,72 @@ class ParserTests: XCTestCase {
         XCTAssertEqual(statement, expectedStatement)
     }
 
+    func testSelectWithUnaryExpression() throws {
+        let source = "SELECT foo FROM bar WHERE baz IS NOT NULL"
+        guard case .success(let tokens) = lex(source) else {
+            XCTFail("Lexing failed unexpectedly")
+            return
+        }
+
+        guard case .success(_, .select(let statement)) = parseSelectStatement(tokens, 0) else {
+            XCTFail("Parsing failed unexpectedly")
+            return
+        }
+
+        let expectedStatement = SelectStatement(
+            Token(kind: .identifier("bar"), location: Location(line: 0, column: 16)),
+            [
+                .expression(.term(Token(kind: .identifier("foo"), location: Location(line: 0, column: 7))))
+            ],
+            .unary(
+                .term(Token(kind: .identifier("baz"), location: Location(line: 0, column: 26))),
+                [
+                    Token(kind: .keyword(.is), location: Location(line: 0, column: 30)),
+                    Token(kind: .keyword(.not), location: Location(line: 0, column: 33)),
+                    Token(kind: .keyword(.null), location: Location(line: 0, column: 37)),
+                ]
+            )
+        )
+        XCTAssertEqual(statement, expectedStatement)
+    }
+
+    func testSelectWithUnaryExpressionInsideBinaryExpression() throws {
+        let source = "SELECT foo FROM bar WHERE baz IS NOT NULL AND quux = 42"
+        guard case .success(let tokens) = lex(source) else {
+            XCTFail("Lexing failed unexpectedly")
+            return
+        }
+
+        guard case .success(_, .select(let statement)) = parseSelectStatement(tokens, 0) else {
+            XCTFail("Parsing failed unexpectedly")
+            return
+        }
+
+        let expectedStatement = SelectStatement(
+            Token(kind: .identifier("bar"), location: Location(line: 0, column: 16)),
+            [
+                .expression(.term(Token(kind: .identifier("foo"), location: Location(line: 0, column: 7))))
+            ],
+            .binary(
+                .unary(
+                    .term(Token(kind: .identifier("baz"), location: Location(line: 0, column: 26))),
+                    [
+                        Token(kind: .keyword(.is), location: Location(line: 0, column: 30)),
+                        Token(kind: .keyword(.not), location: Location(line: 0, column: 33)),
+                        Token(kind: .keyword(.null), location: Location(line: 0, column: 37)),
+                    ]
+                ),
+                .binary(
+                    .term(Token(kind: .identifier("quux"), location: Location(line: 0, column: 46))),
+                    .term(Token(kind: .numeric("42"), location: Location(line: 0, column: 53))),
+                    Token(kind: .symbol(.equals), location: Location(line: 0, column: 51))
+                ),
+                Token(kind: .keyword(.and), location: Location(line: 0, column: 42))
+            )
+        )
+        XCTAssertEqual(statement, expectedStatement)
+    }
+
     func testInvalidSelectStatementsShouldFailToParse() throws {
         for source in [
             "SELECT FROM bar",

--- a/MyOwnSQLTests/ParserTests.swift
+++ b/MyOwnSQLTests/ParserTests.swift
@@ -274,11 +274,11 @@ class ParserTests: XCTestCase {
         let expectedStatement = CreateStatement(
             Token(kind: .identifier("foo"), location: Location(line: 0, column: 13)),
             [
-                .column(Token(kind: .identifier("bar"), location: Location(line: 0, column: 18)),
+                .implicitlyNullableColumn(Token(kind: .identifier("bar"), location: Location(line: 0, column: 18)),
                         Token(kind: .keyword(Keyword(rawValue: "int")!), location: Location(line: 0, column: 22))),
-                .column(Token(kind: .identifier("baz"), location: Location(line: 0, column: 27)),
+                .implicitlyNullableColumn(Token(kind: .identifier("baz"), location: Location(line: 0, column: 27)),
                         Token(kind: .keyword(Keyword(rawValue: "text")!), location: Location(line: 0, column: 31))),
-                .column(Token(kind: .identifier("quux"), location: Location(line: 0, column: 37)),
+                .implicitlyNullableColumn(Token(kind: .identifier("quux"), location: Location(line: 0, column: 37)),
                         Token(kind: .keyword(Keyword(rawValue: "boolean")!), location: Location(line: 0, column: 42))),
             ]
         )

--- a/MyOwnSQLTests/ParserTests.swift
+++ b/MyOwnSQLTests/ParserTests.swift
@@ -274,12 +274,54 @@ class ParserTests: XCTestCase {
         let expectedStatement = CreateStatement(
             Token(kind: .identifier("foo"), location: Location(line: 0, column: 13)),
             [
-                .implicitlyNullableColumn(Token(kind: .identifier("bar"), location: Location(line: 0, column: 18)),
-                        Token(kind: .keyword(Keyword(rawValue: "int")!), location: Location(line: 0, column: 22))),
-                .implicitlyNullableColumn(Token(kind: .identifier("baz"), location: Location(line: 0, column: 27)),
-                        Token(kind: .keyword(Keyword(rawValue: "text")!), location: Location(line: 0, column: 31))),
-                .implicitlyNullableColumn(Token(kind: .identifier("quux"), location: Location(line: 0, column: 37)),
-                        Token(kind: .keyword(Keyword(rawValue: "boolean")!), location: Location(line: 0, column: 42))),
+                .implicitlyNullableColumn(
+                    Token(kind: .identifier("bar"), location: Location(line: 0, column: 18)),
+                    Token(kind: .keyword(.int), location: Location(line: 0, column: 22))
+                ),
+                .implicitlyNullableColumn(
+                    Token(kind: .identifier("baz"), location: Location(line: 0, column: 27)),
+                    Token(kind: .keyword(.text), location: Location(line: 0, column: 31))
+                ),
+                .implicitlyNullableColumn(
+                    Token(kind: .identifier("quux"), location: Location(line: 0, column: 37)),
+                    Token(kind: .keyword(.boolean), location: Location(line: 0, column: 42))
+                ),
+            ]
+        )
+        XCTAssertEqual(statement, expectedStatement)
+    }
+
+    func testParseCreateStatementWithNullQualifiers() throws {
+        let source = "CREATE TABLE foo(bar INT, baz TEXT NULL, quux BOOLEAN NOT NULL)"
+        guard case .success(let tokens) = lex(source) else {
+            XCTFail("Lexing failed unexpectedly")
+            return
+        }
+
+        guard case .success(_, .create(let statement)) = parseCreateStatement(tokens, 0) else {
+            XCTFail("Parsing failed unexpectedly")
+            return
+        }
+        let expectedStatement = CreateStatement(
+            Token(kind: .identifier("foo"), location: Location(line: 0, column: 13)),
+            [
+                .implicitlyNullableColumn(
+                    Token(kind: .identifier("bar"), location: Location(line: 0, column: 17)),
+                    Token(kind: .keyword(.int), location: Location(line: 0, column: 21))
+                ),
+                .explicitlyNullableColumn(
+                    Token(kind: .identifier("baz"), location: Location(line: 0, column: 26)),
+                    Token(kind: .keyword(.text), location: Location(line: 0, column: 30)),
+                    Token(kind: .keyword(.null), location: Location(line: 0, column: 35))
+                ),
+                .notNullableColumn(
+                    Token(kind: .identifier("quux"), location: Location(line: 0, column: 41)),
+                    Token(kind: .keyword(.boolean), location: Location(line: 0, column: 46)),
+                    [
+                        Token(kind: .keyword(.not), location: Location(line: 0, column: 54)),
+                        Token(kind: .keyword(.null), location: Location(line: 0, column: 58))
+                    ]
+                ),
             ]
         )
         XCTAssertEqual(statement, expectedStatement)


### PR DESCRIPTION
This PR accomplishes the following all involving the support of the usage of `NULL`:

* Be able to create tables and declare that columns are explicitly nullable or not nullable. Right now, the following create statement will be successfully executed:

```
CREATE TABLE dresses(id INT NOT NULL, description TEXT NOT NULL, comment TEXT NULL);
```

* Insert a `NULL` value into a nullable column, as well as forbid the the insertion of a `NULL` value into a non-nullable column
* Update a nullable column with a `NULL` value, as well as forbid the the updating of a `NULL` value into a non-nullable column
* Use `IS NULL` and `IS NOT NULL` in `SELECT` and `WHERE` expressions, and have rows properly filtered accordingly for the latter
* Properly print `NULL` values as blanks in the REPL