### PR TITLE
Parse and execute `SELECT` statements with `ORDER BY` clause

### DIFF
--- a/MyOwnSQL/LexerTypes.swift
+++ b/MyOwnSQL/LexerTypes.swift
@@ -33,6 +33,8 @@ enum Keyword: String, CaseIterable {
     case not = "not"
     case null = "null"
     case `is` = "is"
+    case order = "order"
+    case by = "by"
 }
 
 enum Symbol: String, CaseIterable {

--- a/MyOwnSQL/LexerTypes.swift
+++ b/MyOwnSQL/LexerTypes.swift
@@ -35,6 +35,8 @@ enum Keyword: String, CaseIterable {
     case `is` = "is"
     case order = "order"
     case by = "by"
+    case asc = "asc"
+    case desc = "desc"
 }
 
 enum Symbol: String, CaseIterable {

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -346,9 +346,14 @@ class MemoryBackend {
             let resultSetAndOrderByRows = zip(resultRows, orderByRows)
 
             var predicates: [([MemoryCell], [MemoryCell]) -> Bool] = []
-            for (i, _) in orderByClause.items.enumerated() {
+            for (i, item) in orderByClause.items.enumerated() {
+                var comparator: (MemoryCell, MemoryCell) -> Bool = { $0 < $1 }
+                if let sortOrderToken = item.sortOrder, case .keyword(.desc) = sortOrderToken.kind {
+                    comparator = { $1 < $0 }
+                }
+
                 let predicate = { (orderByRow1: [MemoryCell], orderByRow2: [MemoryCell]) -> Bool in
-                    return orderByRow1[i] < orderByRow2[i]
+                    return comparator(orderByRow1[i], orderByRow2[i])
                 }
                 predicates.append(predicate)
             }

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -23,6 +23,10 @@ extension MemoryCell: Comparable {
             return text1 < text2
         case (.booleanValue(let bool1), .booleanValue(let bool2)):
             return (bool1 ? 1 : 0) < (bool2 ? 1 : 0)
+        case (.null, .intValue), (.null, .textValue), (.null, .booleanValue):
+            return false
+        case (.intValue, .null), (.textValue, .null), (.booleanValue, .null):
+            return true
         default:
             return false
         }

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -241,7 +241,7 @@ class MemoryBackend {
 
         if let orderByClause = select.orderByClause {
             for item in orderByClause.items {
-                if case .failure(let error) = typeCheck(item, table) {
+                if case .failure(let error) = typeCheck(item.expression, table) {
                     return .failure(error)
                 }
             }
@@ -332,11 +332,11 @@ class MemoryBackend {
 
             if let orderByClause = select.orderByClause {
                 var orderByRow: [MemoryCell] = []
-                for itemExpression in orderByClause.items {
-                    guard let orderByItem = evaluateExpression(itemExpression, table, tableRow) else {
+                for item in orderByClause.items {
+                    guard let orderByValue = evaluateExpression(item.expression, table, tableRow) else {
                         return .failure(.misc("Could not evaulate expression in ORDER BY clause"))
                     }
-                    orderByRow.append(orderByItem)
+                    orderByRow.append(orderByValue)
                 }
                 orderByRows.append(orderByRow)
             }

--- a/MyOwnSQL/ParserTypes.swift
+++ b/MyOwnSQL/ParserTypes.swift
@@ -68,10 +68,19 @@ struct CreateStatement: Equatable {
     }
 }
 
+struct OrderByClause: Equatable {
+    var items: [Expression]
+
+    init(_ items: [Expression]) {
+        self.items = items
+    }
+}
+
 struct SelectStatement: Equatable {
     var table: Token
     var items: [SelectItem]
     var whereClause: Expression? = nil
+    var orderByClause: OrderByClause? = nil
 
     init(_ table: Token, _ items: [SelectItem]) {
         self.table = table

--- a/MyOwnSQL/ParserTypes.swift
+++ b/MyOwnSQL/ParserTypes.swift
@@ -68,16 +68,15 @@ struct CreateStatement: Equatable {
     }
 }
 
-enum SortOrder: Equatable {
-    case asc
-    case desc
-}
-
 struct OrderByItem: Equatable {
     var expression: Expression
-    var sortOrder: SortOrder
+    var sortOrder: Token?
 
-    init(_ expression: Expression, _ sortOrder: SortOrder) {
+    init(_ expression: Expression) {
+        self.expression = expression
+    }
+
+    init(_ expression: Expression, _ sortOrder: Token) {
         self.expression = expression
         self.sortOrder = sortOrder
     }

--- a/MyOwnSQL/ParserTypes.swift
+++ b/MyOwnSQL/ParserTypes.swift
@@ -68,10 +68,25 @@ struct CreateStatement: Equatable {
     }
 }
 
-struct OrderByClause: Equatable {
-    var items: [Expression]
+enum SortOrder: Equatable {
+    case asc
+    case desc
+}
 
-    init(_ items: [Expression]) {
+struct OrderByItem: Equatable {
+    var expression: Expression
+    var sortOrder: SortOrder
+
+    init(_ expression: Expression, _ sortOrder: SortOrder) {
+        self.expression = expression
+        self.sortOrder = sortOrder
+    }
+}
+
+struct OrderByClause: Equatable {
+    var items: [OrderByItem]
+
+    init(_ items: [OrderByItem]) {
         self.items = items
     }
 }

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -216,12 +216,19 @@ func parseOrderByItems(_ tokens: [Token], _ tokenCursor: Int, _ delimiters: [Tok
     var items: [OrderByItem] = []
 
     while tokenCursorCopy < tokens.count {
-        guard case .success(let newTokenCursorCopy, let expression) = parseExpression(tokens, tokenCursorCopy, delimiters, 0) else {
+        let additionalDelimiters: [TokenKind] = [.keyword(.asc), .keyword(.desc)]
+        guard case .success(let newTokenCursorCopy, let expression) = parseExpression(tokens, tokenCursorCopy, delimiters + additionalDelimiters, 0) else {
             return .failure("Expression expected but not found")
         }
-        let item = OrderByItem(expression, .asc)
-        items.append(item)
         tokenCursorCopy = newTokenCursorCopy
+
+        var item = OrderByItem(expression)
+        if tokenCursorCopy < tokens.count &&
+            (.keyword(.asc) == tokens[tokenCursorCopy].kind || .keyword(.desc) == tokens[tokenCursorCopy].kind) {
+            item.sortOrder = tokens[tokenCursorCopy]
+            tokenCursorCopy += 1
+        }
+        items.append(item)
 
         guard tokenCursorCopy < tokens.count, case .symbol(.comma) = tokens[tokenCursorCopy].kind else {
             break

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -223,6 +223,8 @@ func parseOrderByItems(_ tokens: [Token], _ tokenCursor: Int, _ delimiters: [Tok
         tokenCursorCopy = newTokenCursorCopy
 
         var item = OrderByItem(expression)
+        // TODO: Think about how to fail if a token other than a
+        //       comma or semicolon is found after expression
         if tokenCursorCopy < tokens.count &&
             (.keyword(.asc) == tokens[tokenCursorCopy].kind || .keyword(.desc) == tokens[tokenCursorCopy].kind) {
             item.sortOrder = tokens[tokenCursorCopy]

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -249,7 +249,7 @@ func parseSelectStatement(_ tokens: [Token], _ tokenCursor: Int) -> ParseHelperR
 
     switch parseToken(tokens, tokenCursorCopy, .keyword(.where)) {
     case .success(let newTokenCursor, _):
-        switch parseExpression(tokens, newTokenCursor, [.symbol(.semicolon)], 0) {
+        switch parseExpression(tokens, newTokenCursor, [.symbol(.semicolon), .keyword(.order)], 0) {
         case .success(let newTokenCursor, let expression):
             tokenCursorCopy = newTokenCursor
             whereClause = expression

--- a/MyOwnSQLTests/MemoryTests.swift
+++ b/MyOwnSQLTests/MemoryTests.swift
@@ -446,6 +446,117 @@ class MemoryTests: XCTestCase {
         XCTAssertEqual(actualIds, expectedIds)
     }
 
+    func testSelectWithOneOrderByClauseExpression() throws {
+        let database = MemoryBackend()
+        let setup = """
+CREATE TABLE parts(id INT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, weight INT NOT NULL, city TEXT NOT NULL);
+INSERT INTO parts VALUES(1, 'Nut', 'Red', 12, 'London');
+INSERT INTO parts VALUES(2, 'Bolt', 'Green', 17, 'Paris');
+INSERT INTO parts VALUES(3, 'Screw', 'Blue', 17, 'Oslo');
+INSERT INTO parts VALUES(4, 'Screw', 'Red', 14, 'London');
+INSERT INTO parts VALUES(5, 'Cam', 'Blue', 12, 'Paris');
+INSERT INTO parts VALUES(6, 'Cog', 'Red', 19, 'London');
+"""
+        let _ = database.executeStatements(setup)
+
+        let select = "SELECT * FROM parts ORDER BY id;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+        guard case .successfulSelect(let resultSet) = result else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+
+        let expectedIds: [MemoryCell] = [
+            .intValue(1),
+            .intValue(2),
+            .intValue(3),
+            .intValue(4),
+            .intValue(5),
+            .intValue(6),
+        ]
+        let actualIds = resultSet.rows.map { row in
+            return row[0]
+        }
+        XCTAssertEqual(actualIds, expectedIds)
+    }
+
+    func testSelectWithMultipleOrderByClauseExpressions() throws {
+        let database = MemoryBackend()
+        let setup = """
+CREATE TABLE parts(id INT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, weight INT NOT NULL, city TEXT NOT NULL);
+INSERT INTO parts VALUES(1, 'Nut', 'Red', 12, 'London');
+INSERT INTO parts VALUES(2, 'Bolt', 'Green', 17, 'Paris');
+INSERT INTO parts VALUES(3, 'Screw', 'Blue', 17, 'Oslo');
+INSERT INTO parts VALUES(4, 'Screw', 'Red', 14, 'London');
+INSERT INTO parts VALUES(5, 'Cam', 'Blue', 12, 'Paris');
+INSERT INTO parts VALUES(6, 'Cog', 'Red', 19, 'London');
+"""
+        let _ = database.executeStatements(setup)
+
+        let select = "SELECT * FROM parts ORDER BY city, name;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+        guard case .successfulSelect(let resultSet) = result else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+
+        let expectedIds: [MemoryCell] = [
+            .intValue(6),
+            .intValue(1),
+            .intValue(4),
+            .intValue(3),
+            .intValue(2),
+            .intValue(5),
+        ]
+        let actualIds = resultSet.rows.map { row in
+            return row[0]
+        }
+        XCTAssertEqual(actualIds, expectedIds)
+    }
+
+    func testSelectWithWhereClauseAndOrderByClause() throws {
+        let database = MemoryBackend()
+        let setup = """
+CREATE TABLE parts(id INT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, weight INT NOT NULL, city TEXT NOT NULL);
+INSERT INTO parts VALUES(1, 'Nut', 'Red', 12, 'London');
+INSERT INTO parts VALUES(2, 'Bolt', 'Green', 17, 'Paris');
+INSERT INTO parts VALUES(3, 'Screw', 'Blue', 17, 'Oslo');
+INSERT INTO parts VALUES(4, 'Screw', 'Red', 14, 'London');
+INSERT INTO parts VALUES(5, 'Cam', 'Blue', 12, 'Paris');
+INSERT INTO parts VALUES(6, 'Cog', 'Red', 19, 'London');
+"""
+        let _ = database.executeStatements(setup)
+
+        let select = "SELECT * FROM parts WHERE city = 'London' ORDER BY weight;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+        guard case .successfulSelect(let resultSet) = result else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+
+        let expectedIds: [MemoryCell] = [
+            .intValue(1),
+            .intValue(4),
+            .intValue(6),
+        ]
+        let actualIds = resultSet.rows.map { row in
+            return row[0]
+        }
+        XCTAssertEqual(actualIds, expectedIds)
+    }
+
     func testSelectFailsForBadExpressionInSelectClause() throws {
         let database = MemoryBackend()
         let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"
@@ -537,6 +648,22 @@ class MemoryTests: XCTestCase {
 
         XCTAssertEqual(result, .failure(.invalidExpression))
     }
+
+    func testSelectFailsForOrderByClauseReferencingNonexistentColumn() throws {
+        let database = MemoryBackend()
+        let create = "CREATE TABLE dresses (id int, description text, is_fabulous boolean);"
+        let _ = database.executeStatements(create)
+
+        let select = "SELECT * FROM dresses ORDER BY is_velvet;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+
+        XCTAssertEqual(result, .failure(.columnDoesNotExist("is_velvet")))
+    }
+
 
     func testDeleteAllRows() throws {
         let database = MemoryBackend()

--- a/MyOwnSQLTests/MemoryTests.swift
+++ b/MyOwnSQLTests/MemoryTests.swift
@@ -589,6 +589,82 @@ INSERT INTO customers VALUES(5, 'David', 'david@david.com');
         XCTAssertEqual(actualIds, expectedIds)
     }
 
+    func testSelectWithOrderByClauseWithExplicitDescSort() throws {
+        let database = MemoryBackend()
+        let setup = """
+CREATE TABLE parts(id INT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, weight INT NOT NULL, city TEXT NOT NULL);
+INSERT INTO parts VALUES(1, 'Nut', 'Red', 12, 'London');
+INSERT INTO parts VALUES(2, 'Bolt', 'Green', 17, 'Paris');
+INSERT INTO parts VALUES(3, 'Screw', 'Blue', 17, 'Oslo');
+INSERT INTO parts VALUES(4, 'Screw', 'Red', 14, 'London');
+INSERT INTO parts VALUES(5, 'Cam', 'Blue', 12, 'Paris');
+INSERT INTO parts VALUES(6, 'Cog', 'Red', 19, 'London');
+"""
+        let _ = database.executeStatements(setup)
+
+        let select = "SELECT * FROM parts ORDER BY id DESC;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+        guard case .successfulSelect(let resultSet) = result else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+
+        let expectedIds: [MemoryCell] = [
+            .intValue(6),
+            .intValue(5),
+            .intValue(4),
+            .intValue(3),
+            .intValue(2),
+            .intValue(1),
+        ]
+        let actualIds = resultSet.rows.map { row in
+            return row[0]
+        }
+        XCTAssertEqual(actualIds, expectedIds)
+    }
+
+    func testSelectWithOrderByClauseDescAndAsc() throws {
+        let database = MemoryBackend()
+        let setup = """
+CREATE TABLE parts(id INT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, weight INT NOT NULL, city TEXT NOT NULL);
+INSERT INTO parts VALUES(1, 'Nut', 'Red', 12, 'London');
+INSERT INTO parts VALUES(2, 'Bolt', 'Green', 17, 'Paris');
+INSERT INTO parts VALUES(3, 'Screw', 'Blue', 17, 'Oslo');
+INSERT INTO parts VALUES(4, 'Screw', 'Red', 14, 'London');
+INSERT INTO parts VALUES(5, 'Cam', 'Blue', 12, 'Paris');
+INSERT INTO parts VALUES(6, 'Cog', 'Red', 19, 'London');
+"""
+        let _ = database.executeStatements(setup)
+
+        let select = "SELECT * FROM parts ORDER BY city ASC, name DESC;"
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+        guard case .successfulSelect(let resultSet) = result else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+
+        let expectedIds: [MemoryCell] = [
+            .intValue(4),
+            .intValue(1),
+            .intValue(6),
+            .intValue(3),
+            .intValue(5),
+            .intValue(2),
+        ]
+        let actualIds = resultSet.rows.map { row in
+            return row[0]
+        }
+        XCTAssertEqual(actualIds, expectedIds)
+    }
+
     func testSelectFailsForBadExpressionInSelectClause() throws {
         let database = MemoryBackend()
         let create = "CREATE TABLE dresses (id int, description text, is_in_season boolean);"

--- a/MyOwnSQLTests/ParserTests.swift
+++ b/MyOwnSQLTests/ParserTests.swift
@@ -340,6 +340,7 @@ class ParserTests: XCTestCase {
             "SELECT 42 AS FROM foo",
             "SELECT * AS everything FROM FOO",
             "SELECT * FROM foo WHERE",
+            "SELECT * FROM foo ORDER BY",
         ] {
             guard case .success(let tokens) = lex(source) else {
                 XCTFail("Lexing failed unexpectedly")

--- a/MyOwnSQLTests/ParserTests.swift
+++ b/MyOwnSQLTests/ParserTests.swift
@@ -333,14 +333,14 @@ class ParserTests: XCTestCase {
 
     func testInvalidSelectStatementsShouldFailToParse() throws {
         for source in [
-            "SELECT FROM bar",
-            "SELECT 42 foo",
-            "SELECT 42 FROM",
-            "SELECT 42 'forty-two' FROM foo",
-            "SELECT 42 AS FROM foo",
-            "SELECT * AS everything FROM FOO",
-            "SELECT * FROM foo WHERE",
-            "SELECT * FROM foo ORDER BY",
+            "SELECT FROM bar", // No select items
+            "SELECT 42 foo", // Missing FROM keyword
+            "SELECT 42 FROM", // Missing table name
+            "SELECT 42 'forty-two' FROM foo", // Missing comma between two items
+            "SELECT 42 AS FROM foo", // Missing select item alias
+            "SELECT * AS everything FROM FOO", // Cannot alias the star symbol
+            "SELECT * FROM foo WHERE", // No WHERE expression
+            "SELECT * FROM foo ORDER BY", // No ORDER BY items
         ] {
             guard case .success(let tokens) = lex(source) else {
                 XCTFail("Lexing failed unexpectedly")

--- a/MyOwnSQLTests/ParserTests.swift
+++ b/MyOwnSQLTests/ParserTests.swift
@@ -304,6 +304,33 @@ class ParserTests: XCTestCase {
         XCTAssertEqual(statement, expectedStatement)
     }
 
+    func testSelectWithOrderByClause() throws {
+        let source = "SELECT * FROM dresses ORDER BY description, is_fabulous, id"
+        guard case .success(let tokens) = lex(source) else {
+            XCTFail("Lexing failed unexpectedly")
+            return
+        }
+
+        guard case .success(_, .select(let statement)) = parseSelectStatement(tokens, 0) else {
+            XCTFail("Parsing failed unexpectedly")
+            return
+        }
+
+        var expectedStatement = SelectStatement(
+            Token(kind: .identifier("dresses"), location: Location(line: 0, column: 14)),
+            [
+                .star
+            ]
+        )
+        expectedStatement.orderByClause = OrderByClause([
+            .term(Token(kind: .identifier("description"), location: Location(line: 0, column: 31))),
+            .term(Token(kind: .identifier("is_fabulous"), location: Location(line: 0, column: 44))),
+            .term(Token(kind: .identifier("id"), location: Location(line: 0, column: 57))),
+        ])
+
+        XCTAssertEqual(statement, expectedStatement)
+    }
+
     func testInvalidSelectStatementsShouldFailToParse() throws {
         for source in [
             "SELECT FROM bar",

--- a/MyOwnSQLTests/ParserTests.swift
+++ b/MyOwnSQLTests/ParserTests.swift
@@ -323,9 +323,46 @@ class ParserTests: XCTestCase {
             ]
         )
         expectedStatement.orderByClause = OrderByClause([
-            .term(Token(kind: .identifier("description"), location: Location(line: 0, column: 31))),
-            .term(Token(kind: .identifier("is_fabulous"), location: Location(line: 0, column: 44))),
-            .term(Token(kind: .identifier("id"), location: Location(line: 0, column: 57))),
+            OrderByItem(
+                .term(Token(kind: .identifier("description"), location: Location(line: 0, column: 31)))
+            ),
+            OrderByItem(
+                .term(Token(kind: .identifier("is_fabulous"), location: Location(line: 0, column: 44)))
+            ),
+            OrderByItem(
+                .term(Token(kind: .identifier("id"), location: Location(line: 0, column: 57)))
+            ),
+        ])
+
+        XCTAssertEqual(statement, expectedStatement)
+    }
+
+    func testSelectWithOrderByClauseWithExplicitAscAndDesc() throws {
+        let source = "SELECT * FROM dresses ORDER BY description ASC, id DESC"
+        guard case .success(let tokens) = lex(source) else {
+            XCTFail("Lexing failed unexpectedly")
+            return
+        }
+        guard case .success(_, .select(let statement)) = parseSelectStatement(tokens, 0) else {
+            XCTFail("Parsing failed unexpectedly")
+            return
+        }
+
+        var expectedStatement = SelectStatement(
+            Token(kind: .identifier("dresses"), location: Location(line: 0, column: 14)),
+            [
+                .star
+            ]
+        )
+        expectedStatement.orderByClause = OrderByClause([
+            OrderByItem(
+                .term(Token(kind: .identifier("description"), location: Location(line: 0, column: 31))),
+                Token(kind: .keyword(.asc), location: Location(line: 0, column: 43))
+            ),
+            OrderByItem(
+                .term(Token(kind: .identifier("id"), location: Location(line: 0, column: 48))),
+                Token(kind: .keyword(.desc), location: Location(line: 0, column: 51))
+            ),
         ])
 
         XCTAssertEqual(statement, expectedStatement)


### PR DESCRIPTION
The database engine now supports `SELECT` statements with an `ORDER BY` clause; the following features are included with this release:

* `ORDER BY` clauses can involve one or more expressions
```
SELECT * FROM parts ORDER BY city, name
```
* An `ORDER BY` clause can be combined with a `WHERE` expression 
```
SELECT * FROM parts WHERE city = 'London' ORDER BY name
```
*  Each expression in an `ORDER BY` clause can be qualified with `ASC` or `DESC` to specify the sorting strategy
```
SELECT * FROM parts ORDER BY city ASC, name DESC
```
* `NULL`s sort to the bottom in ascending order, and to the top in descending order

In order to accomplish this, the following changes were made:

* Lexing
	* Consume `ORDER` and `BY` tokens
	* Consume `ASC` and `DESC` as well

* Parsing
	* Add optional `OrderByClause` property to `SelectStatement`
	* Look for optional `ORDER` and `BY` tokens after `WHERE` clause and populate new property
	* Look for optional `ASC` or `DESC` properties as well

* Execution
	* If `SelectStatement` does not have a non-nil `OrderByClause` property, then immediately return rows
	* But if it does, then we need to evaluate each of the order by items for each row sort the result set accordingly
	* `NULL` values sort to the bottom for ascending sort, and to the top for descending sort

* Printing
	* No changes

It should be noted that this post was super helpful in doing this: https://sarunw.com/posts/how-to-sort-by-multiple-properties-in-swift/