### PR TITLE
`SELECT`s now support `CROSS JOIN`

### DIFF
--- a/MyOwnSQL/LexerTypes.swift
+++ b/MyOwnSQL/LexerTypes.swift
@@ -38,6 +38,8 @@ enum Keyword: String, CaseIterable {
     case by = "by"
     case asc = "asc"
     case desc = "desc"
+    case cross = "cross"
+    case join = "join"
 }
 
 enum Symbol: String, CaseIterable {

--- a/MyOwnSQL/LexerTypes.swift
+++ b/MyOwnSQL/LexerTypes.swift
@@ -50,6 +50,7 @@ enum Symbol: String, CaseIterable {
     case equals = "="
     case notEquals = "!="
     case concatenate = "||"
+    case dot = "."
 }
 
 enum TokenKind: Hashable, CustomStringConvertible {

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -224,9 +224,10 @@ class MemoryBackend {
     func selectTable(_ select: SelectStatement) -> StatementExecutionResult {
         var columns: [Column] = []
 
-        guard case .identifier(let tableName) = select.table.kind else {
+        guard case .identifier(let tableName) = select.table.name.kind else {
             return .failure(.misc("Invalid token for table name"))
         }
+
         guard let table = self.tables[tableName] else {
             return .failure(.tableDoesNotExist(tableName))
         }

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -297,6 +297,7 @@ class MemoryBackend {
             }
         }
 
+        // TODO: Need to revisit this; it gets the job done but is messy
         var product: [[TableRow]] = []
         var tempProduct = drivingTable.data.values.map { row in
             [row]

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -295,23 +295,25 @@ class MemoryBackend {
             }
         }
 
-        // TODO: Whoops... I need to make sure that I can emit rows
-        //       when there are no join tables.
         var product: [[[MemoryCell]]] = []
         var tempProduct = drivingTable.data.values.map { row in
             [row]
         }
-        for joinTable in joinTables {
-            product = []
-            for row in tempProduct {
-                for otherRow in joinTable.data.values {
-                    var tempRow = row
-                    tempRow.append(otherRow)
-                    // TODO: If tempRow satisfies join conditions then...
-                    product.append(tempRow)
+        if joinTables.count > 0 {
+            for joinTable in joinTables {
+                product = []
+                for row in tempProduct {
+                    for otherRow in joinTable.data.values {
+                        var tempRow = row
+                        tempRow.append(otherRow)
+                        // TODO: If tempRow satisfies join conditions then...
+                        product.append(tempRow)
+                    }
                 }
+                tempProduct = product
             }
-            tempProduct = product
+        } else {
+            product = tempProduct
         }
 
         var resultRows: [[MemoryCell]] = []
@@ -588,7 +590,6 @@ class MemoryBackend {
                 }
 
                 for table in tables {
-                    let i = table.columnNames.firstIndex(of: requestedColumnName)
                     for (i, columnName) in table.columnNames.enumerated() {
                         if requestedColumnName == columnName {
                             return .success(table.columnTypes[i])

--- a/MyOwnSQL/ParserTypes.swift
+++ b/MyOwnSQL/ParserTypes.swift
@@ -98,18 +98,32 @@ struct OrderByClause: Equatable {
     }
 }
 
+struct SelectedTable: Equatable {
+    var name: Token
+    var alias: Token?
+
+    init(_ name: Token) {
+        self.name = name
+    }
+
+    init(_ name: Token, _ alias: Token) {
+        self.name = name
+        self.alias = alias
+    }
+}
+
 struct SelectStatement: Equatable {
-    var table: Token
+    var table: SelectedTable
     var items: [SelectItem]
     var whereClause: Expression? = nil
     var orderByClause: OrderByClause? = nil
 
-    init(_ table: Token, _ items: [SelectItem]) {
+    init(_ table: SelectedTable, _ items: [SelectItem]) {
         self.table = table
         self.items = items
     }
 
-    init(_ table: Token, _ items: [SelectItem], _ whereClause: Expression) {
+    init(_ table: SelectedTable, _ items: [SelectItem], _ whereClause: Expression) {
         self.table = table
         self.items = items
         self.whereClause = whereClause

--- a/MyOwnSQL/ParserTypes.swift
+++ b/MyOwnSQL/ParserTypes.swift
@@ -112,9 +112,15 @@ struct SelectedTable: Equatable {
     }
 }
 
+struct Join: Equatable {
+    var table: SelectedTable
+    var conditions: Expression?
+}
+
 struct SelectStatement: Equatable {
     var table: SelectedTable
     var items: [SelectItem]
+    var joins: [Join] = []
     var whereClause: Expression? = nil
     var orderByClause: OrderByClause? = nil
 

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -218,14 +218,16 @@ func parseJoins(_ tokens: [Token], _ tokenCursor: Int, _ delimeters: [TokenKind]
     var joins: [Join] = []
 
     while tokenCursorCopy < tokens.count {
-        guard
-            tokenCursorCopy+1 < tokens.count,
-            case .keyword(.cross) = tokens[tokenCursorCopy].kind,
-            case .keyword(.join) = tokens[tokenCursorCopy+1].kind
-        else {
+        if tokenCursorCopy+1 < tokens.count,
+           case .keyword(.cross) = tokens[tokenCursorCopy].kind {
+            if case .keyword(.join) = tokens[tokenCursorCopy+1].kind {
+                tokenCursorCopy += 2
+            } else {
+                return .failure("Unexpected token encountered")
+            }
+        } else {
             break
         }
-        tokenCursorCopy += 2
 
         guard
             tokenCursorCopy < tokens.count,

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -119,6 +119,7 @@ outer:
             .symbol(.concatenate),
             .symbol(.plus),
             .symbol(.asterisk),
+            .symbol(.dot)
         ]
 
         var binaryOperator: Token? = nil

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -274,12 +274,18 @@ func parseSelectStatement(_ tokens: [Token], _ tokenCursor: Int) -> ParseHelperR
     }
     tokenCursorCopy += 1
 
+    var table: SelectedTable
     guard tokenCursorCopy < tokens.count, case .identifier = tokens[tokenCursorCopy].kind else {
         return .failure("Missing table name")
     }
-    let table = tokens[tokenCursorCopy]
+    let tableName = tokens[tokenCursorCopy]
+    table = SelectedTable(tableName)
     tokenCursorCopy += 1
 
+    if tokenCursorCopy < tokens.count, case .identifier = tokens[tokenCursorCopy].kind {
+        table.alias = tokens[tokenCursorCopy]
+        tokenCursorCopy += 1
+    }
     var statement = SelectStatement(table, items)
 
     switch parseToken(tokens, tokenCursorCopy, .keyword(.where)) {
@@ -749,6 +755,8 @@ func bindingPower(_ token: Token) -> Int {
             return 4
         case .asterisk:
             return 5
+        case .dot:
+            return 6
         default:
             return 0
         }

--- a/MyOwnSQL/StatementError.swift
+++ b/MyOwnSQL/StatementError.swift
@@ -15,6 +15,7 @@ enum StatementError: Error, Equatable, LocalizedError {
     case whereClauseNotBooleanExpression
     case columnCannotBeNull(String)
     case duplicateColumn(String)
+    case columnAmbiguouslyDefined(String)
     case typeMismatch
     case notEnoughValues
     case tooManyValues
@@ -37,6 +38,8 @@ enum StatementError: Error, Equatable, LocalizedError {
             return "Column \(columnName) cannot be NULL"
         case .duplicateColumn(let columnName):
             return "Column \(columnName) specified more than once"
+        case .columnAmbiguouslyDefined(let columnName):
+            return "Column \(columnName) ambiguously defined"
         case .typeMismatch:
             return "Type mismatch in SET clause"
         case .notEnoughValues:

--- a/MyOwnSQLTests/MemoryTests.swift
+++ b/MyOwnSQLTests/MemoryTests.swift
@@ -814,7 +814,6 @@ INSERT INTO parts VALUES(6, 'Cog', 'Red', 19, 'London');
         XCTAssertEqual(result, .failure(.columnDoesNotExist("is_velvet")))
     }
 
-
     func testDeleteAllRows() throws {
         let database = MemoryBackend()
         let create = "CREATE TABLE clothes (id int, description text, is_fabulous boolean);"

--- a/MyOwnSQLTests/MemoryTests.swift
+++ b/MyOwnSQLTests/MemoryTests.swift
@@ -119,7 +119,7 @@ class MemoryTests: XCTestCase {
         XCTAssertEqual(dresses.count, 1)
 
         let actualDress = dresses[0]
-        let expectedDress: [MemoryCell] = [
+        let expectedDress: TableRow = [
             .intValue(1),
             .textValue("Long black velvet gown from Lauren"),
             .booleanValue(true)
@@ -150,7 +150,7 @@ class MemoryTests: XCTestCase {
         let rows = Array(table.data.values)
         XCTAssertEqual(rows.count, 3)
 
-        let expectedRows: [[MemoryCell]] = [
+        let expectedRows: [TableRow] = [
             [
                 .intValue(1),
                 .textValue("WHEEEEE!!!"),
@@ -267,7 +267,7 @@ class MemoryTests: XCTestCase {
         XCTAssertEqual(actualColumnNames, expectedColumnNames)
 
         XCTAssertEqual(resultSet.rows.count, 1)
-        let expectedRow: [MemoryCell] = [
+        let expectedRow: TableRow = [
             .intValue(42),
             .textValue("something"),
             .booleanValue(false)
@@ -302,7 +302,7 @@ class MemoryTests: XCTestCase {
         XCTAssertEqual(actualColumnNames, expectedColumnNames)
 
         XCTAssertEqual(resultSet.rows.count, 1)
-        let expectedRow: [MemoryCell] = [
+        let expectedRow: TableRow = [
             .intValue(1),
             .textValue("Velvet dress"),
             .booleanValue(true)
@@ -339,7 +339,7 @@ class MemoryTests: XCTestCase {
         XCTAssertEqual(actualColumnNames, expectedColumnNames)
 
         XCTAssertEqual(resultSet.rows.count, 1)
-        let expectedRow: [MemoryCell] = [
+        let expectedRow: TableRow = [
             .intValue(1),
             .textValue("Long black velvet gown from Lauren"),
         ]
@@ -367,7 +367,7 @@ class MemoryTests: XCTestCase {
         }
 
         XCTAssertEqual(resultSet.rows.count, 1)
-        let expectedRow: [MemoryCell] = [
+        let expectedRow: TableRow = [
             .intValue(1),
             .textValue("Long black velvet gown from Lauren"),
             .null
@@ -410,7 +410,7 @@ class MemoryTests: XCTestCase {
             }
 
             XCTAssertEqual(resultSet.rows.count, 1)
-            let expectedRow: [MemoryCell] = [
+            let expectedRow: TableRow = [
                 expectedValue
             ]
             let actualRow = resultSet.rows[0]
@@ -443,7 +443,7 @@ class MemoryTests: XCTestCase {
         }
 
         XCTAssertEqual(resultSet.rows.count, 1)
-        let expectedRow: [MemoryCell] = [
+        let expectedRow: TableRow = [
             .intValue(2),
             .textValue("Linen shirt"),
             .null,
@@ -698,7 +698,7 @@ ORDER BY t.description, b.description;
             return
         }
 
-        let expectedRows: [[MemoryCell]] = [
+        let expectedRows: [TableRow] = [
             [.textValue("Patterned reef suit"), .textValue("Black velvet skirt")],
             [.textValue("Patterned reef suit"), .textValue("Blue shiny leggings")],
             [.textValue("Purple velvet blouse"), .textValue("Black velvet skirt")],
@@ -739,7 +739,7 @@ ORDER BY t.id;
             return
         }
 
-        let expectedRows: [[MemoryCell]] = [
+        let expectedRows: [TableRow] = [
             [.textValue("Purple velvet blouse"), .textValue("Black velvet skirt")],
             [.textValue("Silver silk blouse"), .textValue("Blue shiny leggings")],
         ]
@@ -969,7 +969,7 @@ INSERT INTO parts VALUES(6, 'Cog', 'Red', 19, 'London');
             XCTFail("Something unexpected happened")
             return
         }
-        let expectedRow: [MemoryCell] = [
+        let expectedRow: TableRow = [
             .intValue(1),
             .textValue("Long black velvet gown from Lauren"),
             .booleanValue(true)
@@ -1085,7 +1085,7 @@ INSERT INTO parts VALUES(6, 'Cog', 'Red', 19, 'London');
         }
 
         XCTAssertEqual(resultSet.rows.count, 1)
-        let expectedRow: [MemoryCell] = [
+        let expectedRow: TableRow = [
             .null,
         ]
         let actualRow = resultSet.rows[0]

--- a/MyOwnSQLTests/ParserTests.swift
+++ b/MyOwnSQLTests/ParserTests.swift
@@ -531,6 +531,7 @@ class ParserTests: XCTestCase {
             "SELECT * AS everything FROM FOO", // Cannot alias the star symbol
             "SELECT * FROM foo WHERE", // No WHERE expression
             "SELECT * FROM foo ORDER BY", // No ORDER BY items
+            "SELECT * FROM foo CROSS bar", // Missing JOIN keyword
         ] {
             guard case .success(let tokens) = lex(source) else {
                 XCTFail("Lexing failed unexpectedly")


### PR DESCRIPTION
Users can now issue `SELECT` statements involving cross joins with one or more tables. To clarify, a cross join between table A and table B results in the Cartesian product of the two, and no join predicates are allowed. Table aliasing is supported, and so you can do the following:

```
SELECT f.bar, q.quux FROM foo f CROSS JOIN quux q
```

However, as of this time aliases cannot be used in conjunction with star, e.g. `a.*`; this shortcoming has been captured in https://github.com/quephird/MyOwnSQL/issues/56