### PR TITLE
Support `alias.*` expressions

### DIFF
--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -282,8 +282,6 @@ class MemoryBackend {
             }
         }
 
-        // TODO: Do we really need to type check here or just check
-        //       to see if we have a valid expression for each select item?
         for item in select.items {
             switch item {
             case .expression(let expression):
@@ -350,6 +348,10 @@ class MemoryBackend {
             for (i, item) in select.items.enumerated() {
                 switch item {
                 case .expression(let expression):
+                    // NOTA BENE: We first check if we're dealing with a top-level
+                    //            star expression, and if so, we bypass the standard
+                    //            call to evaluateExpression() because it only returns
+                    //            a scalar value, not an array of them.
                     if case .term(let token) = expression,
                        case .symbol(.asterisk) = token.kind {
                         if isFirstRow {

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -374,14 +374,17 @@ class MemoryBackend {
                               case .symbol(.asterisk) = maybeStarToken.kind,
                               case .symbol(.dot) = maybeDotToken.kind {
                         if let tableName = tableAliases[alias],
-                           let table = self.tables[tableName] {
+                           let table = self.tables[tableName],
+                           let tableIndex = allTables.firstIndex(where: { $0.name == tableName })
+                        {
                             if isFirstRow {
                                 for (i, columnName) in table.columnNames.enumerated() {
                                     columns.append(Column(columnName, table.columnTypes[i]))
                                 }
                             }
+
                             for (j, _) in table.columnNames.enumerated() {
-                                resultRow.append(tableRows[i][j])
+                                resultRow.append(tableRows[tableIndex][j])
                             }
                             continue
                         } else {

--- a/MyOwnSQL/Memory.swift
+++ b/MyOwnSQL/Memory.swift
@@ -310,9 +310,6 @@ class MemoryBackend {
                 if case .failure(let error) = typeCheck(expression, allTables, tableAliases) {
                     return .failure(error)
                 }
-            // TODO: Need to deprecate
-            case .star:
-                continue
             }
         }
 
@@ -457,20 +454,6 @@ class MemoryBackend {
                     }
 
                     resultRow.append(value)
-                // TODO: Need to move this logic below
-                case .star:
-                    if isFirstRow {
-                        for table in allTables {
-                            for (i, columnName) in table.columnNames.enumerated() {
-                                columns.append(Column(columnName, table.columnTypes[i]))
-                            }
-                        }
-                    }
-                    for (i, table) in allTables.enumerated() {
-                        for (j, _) in table.columnNames.enumerated() {
-                            resultRow.append(tableRows[i][j])
-                        }
-                    }
                 }
             }
             isFirstRow = false

--- a/MyOwnSQL/ParserTypes.swift
+++ b/MyOwnSQL/ParserTypes.swift
@@ -11,6 +11,29 @@ indirect enum Expression: Equatable {
     case binary(Expression, Expression, Token)
 }
 
+extension Expression {
+    var isTopLevelStarExpression: Bool {
+        switch self {
+        case .term(let token):
+            if case .symbol(.asterisk) = token.kind {
+                return true
+            }
+        case .binary(let leftExpr, let rightExpr, let operatorToken):
+            if case .term(let aliasToken) = leftExpr,
+               case .identifier = aliasToken.kind,
+               case .term(let asteriskToken) = rightExpr,
+               case .symbol(.asterisk) = asteriskToken.kind,
+               case .symbol(.dot) = operatorToken.kind {
+                return true
+            }
+        default:
+            return false
+        }
+
+        return false
+    }
+}
+
 enum SelectItem: Equatable {
     case expression(Expression)
     case expressionWithAlias(Expression, Token)

--- a/MyOwnSQL/ParserTypes.swift
+++ b/MyOwnSQL/ParserTypes.swift
@@ -14,7 +14,6 @@ indirect enum Expression: Equatable {
 enum SelectItem: Equatable {
     case expression(Expression)
     case expressionWithAlias(Expression, Token)
-    case star
 }
 
 enum Definition: Equatable {

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -182,29 +182,25 @@ func parseSelectItems(_ tokens: [Token], _ tokenCursor: Int) -> ParseHelperResul
     var items: [SelectItem] = []
 
     while tokenCursorCopy < tokens.count {
-//        if case .symbol(.asterisk) = tokens[tokenCursorCopy].kind {
-//            items.append(.star)
-//            tokenCursorCopy += 1
-//        } else {
-            let delimiters: [TokenKind] = [.keyword(.from), .keyword(.as), .symbol(.comma)]
-            guard case .success(let newTokenCursorCopy, let expression) = parseExpression(tokens, tokenCursorCopy, delimiters, 0) else {
-                return .failure("Expression expected but not found")
-            }
-            tokenCursorCopy = newTokenCursorCopy
+        let delimiters: [TokenKind] = [.keyword(.from), .keyword(.as), .symbol(.comma)]
+        guard case .success(let newTokenCursorCopy, let expression) = parseExpression(tokens, tokenCursorCopy, delimiters, 0) else {
+            return .failure("Expression expected but not found")
+        }
+        tokenCursorCopy = newTokenCursorCopy
 
         // TODO: Need to check if previously consumed token was an asterisk
-            if case .keyword(.as) = tokens[tokenCursorCopy].kind {
-                tokenCursorCopy += 1
+        if case .keyword(.as) = tokens[tokenCursorCopy].kind,
+           !expression.isTopLevelStarExpression {
+            tokenCursorCopy += 1
 
-                guard case .identifier = tokens[tokenCursorCopy].kind else {
-                    return .failure("Identifier expected after AS keyword")
-                }
-                items.append(.expressionWithAlias(expression, tokens[tokenCursorCopy]))
-                tokenCursorCopy += 1
-            } else {
-                items.append(.expression(expression))
+            guard case .identifier = tokens[tokenCursorCopy].kind else {
+                return .failure("Identifier expected after AS keyword")
             }
-//        }
+            items.append(.expressionWithAlias(expression, tokens[tokenCursorCopy]))
+            tokenCursorCopy += 1
+        } else {
+            items.append(.expression(expression))
+        }
 
         guard tokenCursorCopy < tokens.count, case .symbol(.comma) = tokens[tokenCursorCopy].kind else {
             break

--- a/MyOwnSQL/Parsers.swift
+++ b/MyOwnSQL/Parsers.swift
@@ -44,7 +44,7 @@ func parseTermExpression(_ tokens: [Token], _ tokenCursor: Int) -> ParseHelperRe
     // TODO: Consider instead being able to handle tokens
     //       for true and false keywords, and removing the
     //       boolean token type
-    case .identifier, .string, .numeric, .boolean, .keyword(.null):
+    case .identifier, .string, .numeric, .boolean, .keyword(.null), .symbol(.asterisk):
         return .success(tokenCursor+1, Expression.term(maybeTermToken))
     default:
         return .failure("Term expression not found")
@@ -182,16 +182,17 @@ func parseSelectItems(_ tokens: [Token], _ tokenCursor: Int) -> ParseHelperResul
     var items: [SelectItem] = []
 
     while tokenCursorCopy < tokens.count {
-        if case .symbol(.asterisk) = tokens[tokenCursorCopy].kind {
-            items.append(.star)
-            tokenCursorCopy += 1
-        } else {
+//        if case .symbol(.asterisk) = tokens[tokenCursorCopy].kind {
+//            items.append(.star)
+//            tokenCursorCopy += 1
+//        } else {
             let delimiters: [TokenKind] = [.keyword(.from), .keyword(.as), .symbol(.comma)]
             guard case .success(let newTokenCursorCopy, let expression) = parseExpression(tokens, tokenCursorCopy, delimiters, 0) else {
                 return .failure("Expression expected but not found")
             }
             tokenCursorCopy = newTokenCursorCopy
 
+        // TODO: Need to check if previously consumed token was an asterisk
             if case .keyword(.as) = tokens[tokenCursorCopy].kind {
                 tokenCursorCopy += 1
 
@@ -203,7 +204,7 @@ func parseSelectItems(_ tokens: [Token], _ tokenCursor: Int) -> ParseHelperResul
             } else {
                 items.append(.expression(expression))
             }
-        }
+//        }
 
         guard tokenCursorCopy < tokens.count, case .symbol(.comma) = tokens[tokenCursorCopy].kind else {
             break

--- a/MyOwnSQLTests/MemoryTests.swift
+++ b/MyOwnSQLTests/MemoryTests.swift
@@ -746,6 +746,44 @@ ORDER BY t.id;
         XCTAssertEqual(resultSet.rows, expectedRows)
     }
 
+    func testSelectCrossJoinWithAliasedStarExpression() throws {
+        let database = MemoryBackend()
+        let setup = """
+CREATE TABLE tops(id INT NOT NULL, description TEXT NOT NULL);
+INSERT INTO tops VALUES(1, 'Purple velvet blouse');
+INSERT INTO tops VALUES(2, 'Silver silk blouse');
+INSERT INTO tops VALUES(3, 'Patterned reef suit');
+CREATE TABLE bottoms(id INT NOT NULL, description TEXT NOT NULL);
+INSERT INTO bottoms VALUES(1, 'Black velvet skirt');
+INSERT INTO bottoms VALUES(2, 'Blue shiny leggings');
+"""
+        let _ = database.executeStatements(setup)
+
+        let select = """
+SELECT b.*
+FROM tops t
+CROSS JOIN bottoms b
+WHERE t.id = b.id
+ORDER BY t.id;
+"""
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+        guard case .successfulSelect(let resultSet) = result else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+
+        let expectedRows: [TableRow] = [
+            [.intValue(1), .textValue("Black velvet skirt")],
+            [.intValue(2), .textValue("Blue shiny leggings")],
+        ]
+        XCTAssertEqual(resultSet.rows, expectedRows)
+    }
+
+
     func testSelectWithOrderByClauseDescAndAsc() throws {
         let database = MemoryBackend()
         let setup = """

--- a/MyOwnSQLTests/MemoryTests.swift
+++ b/MyOwnSQLTests/MemoryTests.swift
@@ -783,6 +783,39 @@ ORDER BY t.id;
         XCTAssertEqual(resultSet.rows, expectedRows)
     }
 
+    func testSelectWithTableCrossJoinedWithItselfAndAliased() throws {
+        let database = MemoryBackend()
+        let setup = """
+CREATE TABLE foo(bar INT NOT NULL);
+INSERT INTO foo VALUES(1);
+INSERT INTO foo VALUES(2);
+"""
+        let _ = database.executeStatements(setup)
+
+        let select = """
+SELECT a.*, b.*
+FROM foo a
+CROSS JOIN foo b
+ORDER BY a.bar, b.bar;
+"""
+        let results = database.executeStatements(select)
+        guard let result = results.first else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+        guard case .successfulSelect(let resultSet) = result else {
+            XCTFail("Something unexpected happened")
+            return
+        }
+
+        let expectedRows: [TableRow] = [
+            [.intValue(1), .intValue(1)],
+            [.intValue(1), .intValue(2)],
+            [.intValue(2), .intValue(1)],
+            [.intValue(2), .intValue(2)],
+        ]
+        XCTAssertEqual(resultSet.rows, expectedRows)
+    }
 
     func testSelectWithOrderByClauseDescAndAsc() throws {
         let database = MemoryBackend()

--- a/MyOwnSQLTests/ParserTests.swift
+++ b/MyOwnSQLTests/ParserTests.swift
@@ -207,7 +207,7 @@ class ParserTests: XCTestCase {
         let expectedStatement = SelectStatement(
             SelectedTable(Token(kind: .identifier("some_table"), location: Location(line: 0, column: 14))),
             [
-                .star
+                .expression(.term(Token(kind: .symbol(.asterisk), location: Location(line: 0, column: 7))))
             ]
         )
         XCTAssertEqual(statement, expectedStatement)
@@ -319,7 +319,7 @@ class ParserTests: XCTestCase {
         var expectedStatement = SelectStatement(
             SelectedTable(Token(kind: .identifier("dresses"), location: Location(line: 0, column: 14))),
             [
-                .star
+                .expression(.term(Token(kind: .symbol(.asterisk), location: Location(line: 0, column: 7))))
             ]
         )
         expectedStatement.orderByClause = OrderByClause([
@@ -351,7 +351,7 @@ class ParserTests: XCTestCase {
         var expectedStatement = SelectStatement(
             SelectedTable(Token(kind: .identifier("dresses"), location: Location(line: 0, column: 14))),
             [
-                .star
+                .expression(.term(Token(kind: .symbol(.asterisk), location: Location(line: 0, column: 7))))
             ]
         )
         expectedStatement.orderByClause = OrderByClause([
@@ -459,7 +459,7 @@ class ParserTests: XCTestCase {
                 Token(kind: .identifier("parts"), location: Location(line: 0, column: 14))
             ),
             [
-                .star
+                .expression(.term(Token(kind: .symbol(.asterisk), location: Location(line: 0, column: 7))))
             ]
         )
         let expectedJoins = [
@@ -492,7 +492,7 @@ class ParserTests: XCTestCase {
                 Token(kind: .identifier("sp"), location: Location(line: 0, column: 29))
             ),
             [
-                .star
+                .expression(.term(Token(kind: .symbol(.asterisk), location: Location(line: 0, column: 7))))
             ],
             .binary(
                 .binary(


### PR DESCRIPTION
In order to properly evaluate aliased star expressions, I needed to move `*` into the expression grammar itself not above it. But doing that required some additional checks, namely to ensure that star expressions, both of the form `*` and `alias.*` are only allowed to be at the top level, not in a nested expression. I also needed to make sure that `alias.*` pulled the columns from the correct table.